### PR TITLE
set IsAsleep earlier, logging/error cleanup, clear deleted svcs from cache

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -12,6 +12,7 @@ import (
 	"github.com/golang/glog"
 
 	kapi "k8s.io/kubernetes/pkg/api"
+	kerrors "k8s.io/kubernetes/pkg/api/errors"
 	"k8s.io/kubernetes/pkg/api/meta"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	kcache "k8s.io/kubernetes/pkg/client/cache"
@@ -220,11 +221,13 @@ func (c *Cache) GetAndCopyEndpoint(namespace, name string) (*kapi.Endpoints, err
 	endpointInterface := c.KubeClient.Endpoints(namespace)
 	endpoint, err := endpointInterface.Get(name)
 	if err != nil {
-		return nil, errors.New(fmt.Sprintf("Error annotating endpoint in namespace %s: %s\n", namespace, err))
+		if !kerrors.IsNotFound(err) {
+			return nil, errors.New(fmt.Sprintf("Error getting endpoint in namespace( %s ): %s", namespace, err))
+		}
 	}
 	copy, err := kapi.Scheme.DeepCopy(endpoint)
 	if err != nil {
-		return nil, errors.New(fmt.Sprintf("Error annotating endpoint in namespace %s: %s\n", namespace, err))
+		return nil, errors.New(fmt.Sprintf("Error copying endpoint in namespace( %s ): %s", namespace, err))
 	}
 	newEndpoint := copy.(*kapi.Endpoints)
 

--- a/pkg/cache/resource-store.go
+++ b/pkg/cache/resource-store.go
@@ -145,11 +145,17 @@ func (s *resourceStore) AddOrModify(obj interface{}) error {
 func (s *resourceStore) DeleteKapiResource(obj interface{}) error {
 	glog.V(3).Infof("Received DELETE event\n")
 	switch r := obj.(type) {
-	case *kapi.Pod, *kapi.Service, *kapi.ReplicationController:
+	case *kapi.Pod, *kapi.ReplicationController:
 		resObj := s.NewResourceFromInterface(r)
 		UID := string(resObj.UID)
 		if s.ResourceInCache(UID) {
 			s.stopResource(resObj)
+		}
+	case *kapi.Service:
+		resObj := s.NewResourceFromInterface(r)
+		UID := string(resObj.UID)
+		if s.ResourceInCache(UID) {
+			s.Indexer.Delete(resObj)
 		}
 	case *kapi.Namespace:
 		resObj := s.NewResourceFromInterface(r)

--- a/pkg/idling/controller.go
+++ b/pkg/idling/controller.go
@@ -3,6 +3,7 @@ package idling
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"time"
 
@@ -62,7 +63,7 @@ func (idler *Idler) sync() {
 	glog.V(1).Infof("Auto-idler: Running project sync")
 	projects, err := idler.resources.Indexer.ByIndex("ofKind", cache.ProjectKind)
 	if err != nil {
-		glog.Errorf("Auto-idler: Error getting projects for sync: %s", err)
+		glog.Errorf("Auto-idler: %s", err)
 		return
 	}
 	namespaces := make(chan string, len(projects))
@@ -79,7 +80,7 @@ func (idler *Idler) startWorker(namespaces <-chan string) {
 	for namespace := range namespaces {
 		err := idler.syncProject(namespace)
 		if err != nil {
-			glog.Errorf("Auto-idler: %v", err)
+			glog.Errorf("Auto-idler: %s", err)
 		}
 	}
 }
@@ -91,66 +92,96 @@ func (idler *Idler) syncProject(namespace string) error {
 	}
 	project, err := idler.resources.GetProject(namespace)
 	if err != nil {
-		return fmt.Errorf("Auto-idler: Error getting project: %v", err)
+		return errors.New(fmt.Sprintf("Auto-idler: %s", err))
 	}
-
-	if !project.IsAsleep {
-		glog.V(2).Infof("Auto-idler: Syncing project: %s ", project.Name)
-		projPods, err := idler.resources.GetProjectPods(namespace)
-		if err != nil {
-			return fmt.Errorf("Auto-idler: Error getting pods in ( %s ): %#v", namespace, err)
-		}
-		for _, pod := range projPods {
-			// Skip the project sync if any pod in the project has not been running for a complete idling cycle, or if controller hasn't been running
-			// for complete idling cycle.
-			if time.Since(pod.(*cache.ResourceObject).RunningTimes[0].Start) < idler.config.IdleQueryPeriod {
-				glog.V(2).Infof("Auto-idler: Ignoring project( %s ), either pod( %s )or controller hasn't been running for complete idling cycle.", namespace, pod.(*cache.ResourceObject).Name)
-				glog.V(2).Infof("Auto-idler: Project( %s )sync complete.", namespace)
-				return nil
-			}
-		}
-
-		svcs, err := idler.resources.GetProjectServices(namespace)
-		if err != nil {
-			return fmt.Errorf("Auto-idler: Error getting services in ( %s ): %#v", namespace, err)
-		}
-		var scalablePods []interface{}
-		var runningPods []interface{}
-		for _, svc := range svcs {
-			// Only consider pods with services for idling.
-			scalablePods := idler.resources.GetPodsForService(svc.(*cache.ResourceObject), projPods)
-			for _, pod := range scalablePods {
-				runningPods = append(runningPods, pod)
-			}
-		}
-
-		// If true, endpoints in namespace are currently idled,
-		// i.e. endpoints in project have idling annotations and len(scalablePods)==0
-		// Project is not currently idled if there are any running scalable pods in namespace.
-		idled, err := idler.checkIdledState(namespace, len(runningPods))
-		if err != nil {
-			return err
-		}
-		if !idled {
-			if err := idler.idleIfInactive(namespace, scalablePods); err != nil {
-				glog.Errorf("Auto-idler: Error syncing project( %s ): %s", namespace, err)
-			}
-		} else {
-			glog.V(2).Infof("Auto-idler: Project( %s )sync complete.", namespace)
-			return nil
-		}
-	} else {
-		glog.V(2).Infof("Auto-idler: Ignoring project( %s ), currently in force-sleep.", namespace)
-		glog.V(2).Infof("Auto-idler: Project( %s )sync complete.", namespace)
+	if project.IsAsleep {
+		glog.V(2).Infof("Auto-idler: Ignoring project( %s ), currently in force-sleep", namespace)
 		return nil
 	}
-	glog.V(2).Infof("Auto-idler: Project( %s )sync complete.", namespace)
+	// If true, endpoints in namespace are currently idled,
+	// i.e. endpoints in project have idling annotations and len(scalablePods)==0
+	// Project is not currently idled if there are any running scalable pods in namespace.
+	idled, err := CheckIdledState(idler.resources, namespace, project.IsAsleep)
+	if err != nil {
+		return errors.New(fmt.Sprintf("Auto-idler: %s", err))
+	}
+	if idled {
+		glog.V(2).Infof("Auto-idler: Project( %s )sync complete", namespace)
+		return nil
+	}
+	services, err := idler.resources.GetProjectServices(namespace)
+	if err != nil {
+		return errors.New(fmt.Sprintf("Auto-idler: %s", err))
+	}
+	if len(services) == 0 {
+		glog.V(2).Infof("Auto-idler: Project( %s )has no services, exiting", namespace)
+		return nil
+	}
+	// Get project again here, to catch any changes to 'IsAsleep' status
+	project, err = idler.resources.GetProject(namespace)
+	if err != nil {
+		return errors.New(fmt.Sprintf("Auto-idler: %s", err))
+	}
+	if project.IsAsleep {
+		glog.V(2).Infof("Auto-idler: Ignoring project( %s ), currently in force-sleep", namespace)
+		return nil
+	}
+	glog.V(2).Infof("Auto-idler: Syncing project: %s ", project.Name)
+	projPods, err := idler.resources.GetProjectPods(namespace)
+	if err != nil {
+		return errors.New(fmt.Sprintf("Auto-idler: %s", err))
+	}
+	for _, pod := range projPods {
+		// Skip the project sync if any pod in the project has not been running for a complete idling cycle, or if controller hasn't been running
+		// for complete idling cycle.
+		if time.Since(pod.(*cache.ResourceObject).RunningTimes[0].Start) < idler.config.IdleQueryPeriod {
+			glog.V(2).Infof("Auto-idler: Ignoring project( %s ), either pod( %s )or controller hasn't been running for complete idling cycle", namespace, pod.(*cache.ResourceObject).Name)
+			glog.V(2).Infof("Auto-idler: Project( %s )sync complete", namespace)
+			return nil
+		}
+	}
+
+	if err := idler.idleIfInactive(namespace); err != nil {
+		return errors.New(fmt.Sprintf("Auto-idler: %s", err))
+	}
+	glog.V(2).Infof("Auto-idler: Project( %s )sync complete", namespace)
 	return nil
 }
 
-func (idler *Idler) idleIfInactive(namespace string, pods []interface{}) error {
-	for _, obj := range pods {
-		pod := obj.(*cache.ResourceObject)
+func (idler *Idler) idleIfInactive(namespace string) error {
+	project, err := idler.resources.GetProject(namespace)
+	if err != nil {
+		return errors.New(fmt.Sprintf("Auto-idler: %s", err))
+	}
+	// Extra check here, not sure it's necessary
+	if project.IsAsleep {
+		glog.V(2).Infof("Auto-idler: Ignoring project( %s ), currently in force-sleep.", namespace)
+		return nil
+	}
+	svcs, err := idler.resources.GetProjectServices(namespace)
+	if err != nil {
+		return errors.New(fmt.Sprintf("Auto-idler: %s", err))
+	}
+	projectPods, err := idler.resources.GetProjectPods(namespace)
+	if err != nil {
+		return errors.New(fmt.Sprintf("Auto-idler: %s", err))
+	}
+	var scalablePods []interface{}
+	for _, svc := range svcs {
+		// Only consider pods with services for idling.
+		podsWService := idler.resources.GetPodsForService(svc.(*cache.ResourceObject), projectPods)
+		for _, pod := range podsWService {
+			scalablePods = append(scalablePods, pod)
+		}
+	}
+	// if there are no running pods, project can't be idled
+	if len(scalablePods) == 0 {
+		glog.V(2).Infof("Auto-idler: No scalable pods in project( %s ), exiting...", namespace)
+		return nil
+	}
+
+	for _, podObj := range projectPods {
+		pod := podObj.(*cache.ResourceObject)
 		if _, ok := pod.Labels[buildapi.BuildAnnotation]; ok {
 			if pod.IsStarted() {
 				glog.V(2).Infof("Auto-idler: Ignoring project( %s ), builder pod( %s ) found in project.", namespace, pod.Name)
@@ -164,58 +195,49 @@ func (idler *Idler) idleIfInactive(namespace string, pods []interface{}) error {
 	}
 	tags := make(map[string]string)
 	var filters []metrics.Modifier
-	project, err := idler.resources.GetProject(namespace)
+	tags["descriptor_name"] = "network/rx"
+	tags["type"] = "pod"
+
+	p := idler.getMetricsParams(namespace)
+
+	period := -1 * idler.config.IdleQueryPeriod
+	endtime := time.Now()
+	starttime := endtime.Add(period)
+	threshold := idler.config.Threshold
+	filters = append(filters, metrics.Filters(metrics.TagsFilter(tags), metrics.BucketsFilter(1), metrics.StartTimeFilter(starttime), metrics.EndTimeFilter(endtime), metrics.StackedFilter()))
+
+	c, err := metrics.NewHawkularClient(p)
 	if err != nil {
-		glog.Errorf("Auto-idler: Error getting project: %v", err)
+		return errors.New(fmt.Sprintf("Auto-idler: %s", err))
 	}
-	if !project.IsAsleep {
-		tags["descriptor_name"] = "network/rx"
-		tags["type"] = "pod"
 
-		p := idler.getMetricsParams(namespace)
+	bp, err := c.ReadBuckets(metrics.Counter, filters...)
+	if err != nil {
+		return errors.New(fmt.Sprintf("Auto-idler: %s", err))
+	}
 
-		period := -1 * idler.config.IdleQueryPeriod
-		endtime := time.Now()
-		starttime := endtime.Add(period)
-		threshold := idler.config.Threshold
-		filters = append(filters, metrics.Filters(metrics.TagsFilter(tags), metrics.BucketsFilter(1), metrics.StartTimeFilter(starttime), metrics.EndTimeFilter(endtime), metrics.StackedFilter()))
+	for _, value := range bp {
+		activity := value.Max - value.Min
+		glog.V(2).Infof("Auto-idler: Project( %s )NETWORK_ACTIVITY(bytes): %v", namespace, int(activity))
 
-		c, err := metrics.NewHawkularClient(p)
-		if err != nil {
-			return err
-		}
-
-		bp, err := c.ReadBuckets(metrics.Counter, filters...)
-		if err != nil {
-			return err
-		}
-
-		for _, value := range bp {
-			activity := value.Max - value.Min
-			glog.V(2).Infof("PROJECT( %s )NETWORK_ACTIVITY(bytes): %v", namespace, int(activity))
-
-			if int(activity) < threshold {
-				glog.V(3).Infof("Project( %s )MaxNetworkRX: %#v", namespace, value.Max)
-				glog.V(3).Infof("Project( %s )MinNetworkRX: %#v", namespace, value.Min)
-				if !idler.config.IdleDryRun {
-					glog.V(2).Infof("Project( %s )activity below idling threshold, idling....", namespace)
-					err := IdleProjectServices(idler.resources, namespace)
-					if err != nil {
-						glog.Errorf("Auto-idler: Namespace( %s ): %s", namespace, err)
-					}
-				} else {
-					glog.V(2).Infof("Project( %s )network activity below idling threshold, but currently in DryRun mode.", namespace)
+		if int(activity) < threshold {
+			glog.V(3).Infof("Auto-idler: Project( %s )MaxNetworkRX: %#v", namespace, value.Max)
+			glog.V(3).Infof("Auto-idler: Project( %s )MinNetworkRX: %#v", namespace, value.Min)
+			if !idler.config.IdleDryRun {
+				glog.V(2).Infof("Auto-idler: Project( %s )activity below idling threshold, idling....", namespace)
+				err := idler.autoIdleProjectServices(namespace)
+				if err != nil {
+					return errors.New(fmt.Sprintf("Auto-idler: %s", err))
 				}
 			} else {
-				glog.V(3).Infof("Project( %s )MaxNetworkRX: %#v", namespace, value.Max)
-				glog.V(3).Infof("Project( %s )MinNetworkRX: %#v", namespace, value.Min)
-				glog.V(2).Infof("Project( %s )network activity is above idling threshold.", namespace)
+				glog.V(2).Infof("Auto-idler: Project( %s )network activity below idling threshold, but currently in DryRun mode.", namespace)
 			}
+		} else {
+			glog.V(3).Infof("Auto-idler: Project( %s )MaxNetworkRX: %#v", namespace, value.Max)
+			glog.V(3).Infof("Auto-idler: Project( %s )MinNetworkRX: %#v", namespace, value.Min)
+			glog.V(2).Infof("Auto-idler: Project( %s )network activity is above idling threshold.", namespace)
 		}
-	} else {
-		glog.V(2).Infof("Auto-idler: Ignoring project( %s ), currently in force-sleep.", namespace)
 	}
-
 	return nil
 }
 
@@ -252,19 +274,114 @@ func (idler *Idler) getMetricsParams(namespace string) metrics.Parameters {
 	return p
 }
 
-// checkIdledState returns true if project is idled, false if project is not currently idled
-func (idler *Idler) checkIdledState(namespace string, numScalablePods int) (bool, error) {
-	endpointInterface := idler.resources.KubeClient.Endpoints(namespace)
-	epList, err := endpointInterface.List(kapi.ListOptions{})
+// CheckIdledState returns true if project is idled, false if project is not currently idled
+// This function checks pod count and endpoint annotations.  This is not 100% fail-proof, bc
+// oc idle code itself has limitations.
+func CheckIdledState(c *cache.Cache, namespace string, IsAsleep bool) (bool, error) {
+	idled := false
+	svcs, err := c.GetProjectServices(namespace)
 	if err != nil {
-		return false, fmt.Errorf("Auto-idler: Project( %s ): %s", namespace, err)
+		return idled, errors.New(fmt.Sprintf("Auto-idler: %s", err))
 	}
-	for _, ep := range epList.Items {
-		if _, ok := ep.ObjectMeta.Annotations[unidlingapi.IdledAtAnnotation]; ok && numScalablePods == 0 {
-			glog.V(2).Infof("Auto-idler: Project( %s )already in idled state.", namespace)
-			return true, nil
+	var runningPods []interface{}
+	projPods, err := c.GetProjectPods(namespace)
+	if err != nil {
+		return idled, errors.New(fmt.Sprintf("Auto-idler: %s", err))
+	}
+	for _, p := range projPods {
+		if p.(*cache.ResourceObject).IsStarted() {
+			runningPods = append(runningPods, p)
 		}
 	}
-	glog.V(3).Infof("Auto-idler: Project( %s )not currently idled, checking network activity received...", namespace)
-	return false, nil
+	var scalablePods []interface{}
+	for _, svc := range svcs {
+		// Only consider pods with services for idling.
+		podsWService := c.GetPodsForService(svc.(*cache.ResourceObject), runningPods)
+		for _, pod := range podsWService {
+			scalablePods = append(scalablePods, pod)
+		}
+	}
+	// if there are any running pods, project is not idled
+	if len(scalablePods) != 0 {
+		idled = false
+		return idled, nil
+	}
+
+	// TODO: Remove any idling annotations from pods with endpoints in the project
+	// Currently, if there are 2 services in a project that share an RC, it's
+	// possible for stale idling annotations to be left in an unidled project
+	// in the endpoints of the service that was not explicitly un-idled, ie if
+	// the project was manually scaled up or if just 1 of the svcs routes were
+	// accessed.  This should be fixed in the oc idle code itself, rather than
+	// in this hibernation controller.  For now, we should document this and
+	// steer users away from setting more than 1 service per RC.
+	endpointInterface := c.KubeClient.Endpoints(namespace)
+	epList, err := endpointInterface.List(kapi.ListOptions{})
+	if err != nil {
+		return idled, errors.New(fmt.Sprintf("Auto-idler: %s", err))
+	}
+	for _, ep := range epList.Items {
+		_, idledAtExists := ep.ObjectMeta.Annotations[unidlingapi.IdledAtAnnotation]
+		_, targetExists := ep.ObjectMeta.Annotations[unidlingapi.UnidleTargetAnnotation]
+		if targetExists && idledAtExists {
+			idled = true
+			if !IsAsleep {
+				glog.V(2).Infof("Project( %s )in idled state", namespace)
+			}
+			return idled, nil
+		}
+
+	}
+	idled = false
+	glog.V(3).Infof("Project( %s )not currently idled", namespace)
+	return idled, nil
+}
+
+// The goal with this is to re-create `oc idle` to the extent we need to, in order to provide automatic re-scaling on project wake
+// `oc idle` links controllers to endpoints by:
+//   1. taking in an endpoint (service name)
+//   2. getting the pods on that endpoint
+//   3. getting the controller on each pod (and, in the case of DCs, getting the controller on that controller)
+// This approach is:
+//   1. loop through all services in project
+//   2. for each service, get pods on service by label selector
+//   3. get the controller on each pod (and, in the case of DCs, get the controller on that controller)
+//   4. get endpoint with the same name as the service
+func (idler *Idler) autoIdleProjectServices(namespace string) error {
+	nowTime := time.Now()
+	project, err := idler.resources.GetProject(namespace)
+	if err != nil {
+		return err
+	}
+	if project.IsAsleep {
+		glog.V(2).Infof("Auto-idler: Project( %s )currently in force-sleep, exiting...", namespace)
+		return nil
+	}
+	glog.V(0).Infof("Auto-idler: Adding previous scale annotation in project( %s )", namespace)
+	err = AddProjectPreviousScaleAnnotation(idler.resources, namespace)
+	if err != nil {
+		return errors.New(fmt.Sprintf("Error adding project( %s )previous scale annotation: %s", namespace, err))
+	}
+	glog.V(2).Infof("Auto-idler: Scaling DCs in project %s", namespace)
+	err = ScaleProjectDCs(idler.resources, namespace)
+	if err != nil {
+		return errors.New(fmt.Sprintf("Error scaling DCs in project %s: %s", namespace, err))
+	}
+
+	glog.V(2).Infof("Auto-idler: Scaling RCs in project %s", namespace)
+	err = ScaleProjectRCs(idler.resources, namespace)
+	if err != nil {
+		return errors.New(fmt.Sprintf("Error scaling RCs in project %s: %s", namespace, err))
+	}
+	glog.V(2).Infof("Auto-idler: Deleting pods in project %s", namespace)
+	err = DeleteProjectPods(idler.resources, namespace)
+	if err != nil {
+		return errors.New(fmt.Sprintf("Error deleting pods in project %s: %s", namespace, err))
+	}
+	glog.V(0).Infof("Auto-idler: Adding idled-at annotation in project( %s )", namespace)
+	err = AddProjectIdledAtAnnotation(idler.resources, namespace, nowTime, idler.config.ProjectSleepPeriod)
+	if err != nil {
+		return errors.New(fmt.Sprintf("Error adding idled-at annotation in project( %s ): %v", namespace, err))
+	}
+	return nil
 }

--- a/pkg/idling/idle.go
+++ b/pkg/idling/idle.go
@@ -17,77 +17,17 @@ import (
 	kerrors "k8s.io/kubernetes/pkg/api/errors"
 )
 
-// These are just to provide the "FullIdleAnnotations" constant to be used as a parameter when idling
 // The unidlingapi constants are copied over for consistency
 const (
 	IdledAtAnnotation       = unidlingapi.IdledAtAnnotation
 	PreviousScaleAnnotation = unidlingapi.PreviousScaleAnnotation
 	UnidleTargetAnnotation  = unidlingapi.UnidleTargetAnnotation
-	FullIdleAnnotations     = "full"
 )
 
 type ControllerScaleReference struct {
 	Kind     string
 	Name     string
 	Replicas int32
-}
-
-// The goal with this is to re-create `oc idle` to the extent we need to, in order to provide automatic re-scaling on project wake
-// `oc idle` links controllers to endpoints by:
-//   1. taking in an endpoint (service name)
-//   2. getting the pods on that endpoint
-//   3. getting the controller on each pod (and, in the case of DCs, getting the controller on that controller)
-// This approach is:
-//   1. loop through all services in project
-//   2. for each service, get pods on service by label selector
-//   3. get the controller on each pod (and, in the case of DCs, get the controller on that controller)
-//   4. get endpoint with the same name as the service
-func IdleProjectServices(c *cache.Cache, namespace string) error {
-	failed := false
-	services, err := c.GetProjectServices(namespace)
-	if err != nil {
-		return err
-	}
-	nowTime := time.Now()
-	// Loop through all of the services in a namespace
-	for _, obj := range services {
-		svc := obj.(*cache.ResourceObject)
-		err = AnnotateService(c, svc, nowTime, namespace, FullIdleAnnotations)
-		if err != nil {
-			glog.Errorf("Error idling service: %s", err)
-			failed = true
-		}
-		glog.V(0).Infof("Added service idled-at annotation( %s )", svc.Name)
-	}
-
-	if failed {
-		return errors.New("Failed to idle all project services")
-	}
-	// TODO: What do we do with pods that have no service? If we scale them, they will remain
-	// scaled down until a user manually scales them up again.. for now, only scale pods with
-	// services...
-	if len(services) != 0 {
-		glog.V(2).Infof("Scaling DCs in project %s\n", namespace)
-		err = ScaleProjectDCs(c, namespace)
-		if err != nil {
-			failed = true
-			glog.Errorf("Error scaling DCs in project %s: %s\n", namespace, err)
-		}
-
-		glog.V(2).Infof("Scaling RCs in project %s\n", namespace)
-		err = ScaleProjectRCs(c, namespace)
-		if err != nil {
-			failed = true
-			glog.Errorf("Error scaling RCs in project %s: %s\n", namespace, err)
-		}
-
-		if failed {
-			return fmt.Errorf("Error idling services in project %s\n", namespace)
-		}
-	} else {
-		glog.V(2).Infof("Did not idle resources in project( %s ), no services found", namespace)
-	}
-	return nil
 }
 
 func ScaleProjectDCs(c *cache.Cache, namespace string) error {
@@ -108,23 +48,19 @@ func ScaleProjectDCs(c *cache.Cache, namespace string) error {
 		newDC.Spec.Replicas = 0
 		_, err = dcInterface.Update(&newDC)
 		if err != nil {
-			if kerrors.IsNotFound(err) {
-				continue
-			} else {
-				glog.Errorf("Error scaling DC in namespace %s: %s\n", namespace, err)
+			if !kerrors.IsNotFound(err) {
+				glog.Errorf("Project( %s) DC( %s ): %s", namespace, dc.Name, err)
 				failed = true
 			}
 		}
-
 	}
 	if failed {
-		return errors.New("Failed to scale all project DCs")
+		return errors.New(fmt.Sprintf("Failed to scale all project( %s)DCs", namespace))
 	}
 	return nil
 }
 
 func ScaleProjectRCs(c *cache.Cache, namespace string) error {
-	failed := false
 	// Scale RCs to 0
 	rcInterface := c.KubeClient.ReplicationControllers(namespace)
 	rcList, err := rcInterface.List(kapi.ListOptions{})
@@ -132,6 +68,7 @@ func ScaleProjectRCs(c *cache.Cache, namespace string) error {
 		return err
 	}
 
+	failed := false
 	for _, thisRC := range rcList.Items {
 		// TODO: Use indexer function 'rcByDC' here for efficiency?
 		// Given thisRC name, check to see if thisRC has a DC
@@ -145,10 +82,8 @@ func ScaleProjectRCs(c *cache.Cache, namespace string) error {
 			newRC.Spec.Replicas = 0
 			_, err = rcInterface.Update(&newRC)
 			if err != nil {
-				if kerrors.IsNotFound(err) {
-					continue
-				} else {
-					glog.Errorf("Error scaling RC in namespace %s: %s\n", namespace, err)
+				if !kerrors.IsNotFound(err) {
+					glog.Errorf("Project( %s) RC( %s ): %s", namespace, thisRC.Name, err)
 					failed = true
 				}
 			}
@@ -158,7 +93,7 @@ func ScaleProjectRCs(c *cache.Cache, namespace string) error {
 		}
 	}
 	if failed {
-		return errors.New("Failed to scale all project RCs")
+		return errors.New(fmt.Sprintf("Failed to scale all project( %s )RCs", namespace))
 	}
 	return nil
 }
@@ -170,20 +105,19 @@ func DeleteProjectPods(c *cache.Cache, namespace string) error {
 	if err != nil {
 		return err
 	}
+
 	failed := false
 	for _, pod := range podList.Items {
 		err = podInterface.Delete(pod.ObjectMeta.Name, &kapi.DeleteOptions{})
 		if err != nil {
-			if kerrors.IsNotFound(err) {
-				continue
-			} else {
-				glog.Errorf("Error deleting pods in namespace %s: %s\n", namespace, err)
+			if !kerrors.IsNotFound(err) {
+				glog.Errorf("Project( %s ) Pod( %s ): %s", namespace, pod.Name, err)
 				failed = true
 			}
 		}
 	}
 	if failed {
-		return errors.New("Failed to delete all project pods")
+		return errors.New(fmt.Sprintf("Failed to delete all project( %s )pods", namespace))
 	}
 	return nil
 }
@@ -197,18 +131,18 @@ func AddProjectPreviousScaleAnnotation(c *cache.Cache, namespace string) error {
 	if err != nil {
 		return err
 	}
-
 	// Loop through all of the services in a namespace
 	for _, obj := range svcs {
 		svc := obj.(*cache.ResourceObject)
+		glog.V(2).Infof("Adding previous scale annotation to service( %s )", svc.Name)
 		err = AnnotateService(c, svc, time.Time{}, namespace, PreviousScaleAnnotation)
 		if err != nil {
-			glog.Errorf("Error idling service: %s", err)
+			glog.Errorf("Project( %s ) Service( %s ): %s", namespace, svc.Name, err)
 			failed = true
 		}
 	}
 	if failed {
-		return errors.New("Failed to idle all project services")
+		return errors.New(fmt.Sprintf("Failed to add previous scale annotation to all project( %s )services", namespace))
 	}
 	return nil
 }
@@ -216,7 +150,7 @@ func AddProjectPreviousScaleAnnotation(c *cache.Cache, namespace string) error {
 // Add idling IdledAtAnnotation to all services in a namespace
 // This should only be called after calling AddProjectPreviousScaleAnnotation(), as it depends on the
 // service's ScaleRefs annotation to determine which controllers belong to a service
-func AddProjectIdledAtAnnotation(c *cache.Cache, namespace string, nowTime time.Time) error {
+func AddProjectIdledAtAnnotation(c *cache.Cache, namespace string, nowTime time.Time, sleepPeriod time.Duration) error {
 	failed := false
 	svcs, err := c.GetProjectServices(namespace)
 	if err != nil {
@@ -228,102 +162,138 @@ func AddProjectIdledAtAnnotation(c *cache.Cache, namespace string, nowTime time.
 		svc := obj.(*cache.ResourceObject)
 		err = AnnotateService(c, svc, nowTime, namespace, IdledAtAnnotation)
 		if err != nil {
-			glog.Errorf("Error idling service: %s", err)
+			glog.Errorf("Project( %s ) Service( %s ): %s", namespace, svc.Name, err)
 			failed = true
 		}
 	}
 	if failed {
-		return errors.New("Failed to idle all project services")
+		return errors.New(fmt.Sprintf("Failed to add idled-at annotation to all project( %s )services", namespace))
 	}
 	return nil
 }
 
 // Adds the requested idling annotations to a service and all controllers in that service
 func AnnotateService(c *cache.Cache, svc *cache.ResourceObject, nowTime time.Time, namespace, annotation string) error {
-	endpointInterface := c.KubeClient.Endpoints(namespace)
-	newEndpoint, err := c.GetAndCopyEndpoint(namespace, svc.Name)
+	project, err := c.GetProject(namespace)
 	if err != nil {
-		return errors.New(fmt.Sprintf("Error annotating Endpoint in namespace %s: %s\n", namespace, err))
+		return err
 	}
-
-	if annotation == PreviousScaleAnnotation || annotation == FullIdleAnnotations {
-		projectPods, err := c.GetProjectPods(namespace)
+	// TODO: Limitation of oc idle and auto-idler: Cannot handle 2 services sharing a single RC.
+	// Projects with 2 services sharing an RC will have unpredictable behavior of idling/auto-idling
+	// This needs to be fixed in oc idle code.  Will document with auto-idling documentation for now.
+	if annotation == PreviousScaleAnnotation {
+		endpointInterface := c.KubeClient.Endpoints(namespace)
+		newEndpoint, err := c.GetAndCopyEndpoint(namespace, svc.Name)
 		if err != nil {
 			return err
 		}
-
-		// Find the pods for this service, then find the scalable resources for those pods
-		pods := c.GetPodsForService(svc, projectPods)
-		resourceRefs, err := c.FindScalableResourcesForService(pods)
+		epList, err := endpointInterface.List(kapi.ListOptions{})
 		if err != nil {
-			return errors.New(fmt.Sprintf("Error scaling service: %s\n", err))
+			return err
 		}
-
-		// Store the scalable resources in a map (this will become an annotation on the service later)
-		scaleRefs := make(map[kapi.ObjectReference]*ControllerScaleReference)
-		for ref := range resourceRefs {
-			scaleRef, err := AnnotateController(c, ref, nowTime, annotation)
-			if err != nil {
-				return errors.New(fmt.Sprintf("Error annotating controller: %s\n", err))
+		for _, ep := range epList.Items {
+			// Need to delete any previous IdledAtAnnotations to prevent premature unidling
+			if newEndpoint.Annotations[unidlingapi.IdledAtAnnotation] != "" {
+				if project.IsAsleep {
+					glog.V(2).Infof("Force-sleeper: Removing stale idled-at annotation in endpoint( %s ) project( %s )", ep.Name, namespace)
+				} else {
+					glog.V(2).Infof("Auto-idler: Removing stale idled-at annotation in endpoint( %s ) project( %s )", ep.Name, namespace)
+				}
+				delete(newEndpoint.Annotations, unidlingapi.IdledAtAnnotation)
 			}
-			scaleRefs[ref] = scaleRef
-		}
+			_, targetExists := ep.ObjectMeta.Annotations[unidlingapi.UnidleTargetAnnotation]
+			// TODO: It's possible that the unidle target that already exists has a replica that is
+			// not up-to-date.  For instance, a project was *manually* unidled, then scaled.  Then if
+			// the project is auto-idled, the unidle target annotation will hold the replicas of the
+			// original scale, before the project was manually scaled.
+			// For now, skip setting new unidle target when one already exists in an endpoint,
+			// at the risk of keeping an outdated scale, to prevent unidle-target being set to 0. It's
+			// not currently possible to predict if project is currently in the process of becoming idled.
+			// This needs to be fixed in oc idle/web-console code.
+			if targetExists {
+				if !project.IsAsleep {
+					glog.V(2).Infof("Auto-idler: Service( %s ), endpoint( %s )already has unidle target annotation, skipping previous scale annotation...", svc.Name, ep.Name)
+				} else {
+					glog.V(2).Infof("Force-sleeper: Service( %s ), endpoint( %s )already has unidle target annotation, skipping previous scale annotation...", svc.Name, ep.Name)
+				}
+			} else {
+				projectPods, err := c.GetProjectPods(namespace)
+				if err != nil {
+					return err
+				}
+				// Find the pods for this service, then find the scalable resources for those pods
+				pods := c.GetPodsForService(svc, projectPods)
+				resourceRefs, err := c.FindScalableResourcesForService(pods)
+				if err != nil {
+					return err
+				}
+				// Store the scalable resources in a map (this will become an annotation on the service later)
+				scaleRefs := make(map[kapi.ObjectReference]*ControllerScaleReference)
+				for ref := range resourceRefs {
+					scaleRef, err := AnnotateController(c, ref, nowTime, annotation, project.IsAsleep)
+					if err != nil {
+						return err
+					}
+					scaleRefs[ref] = scaleRef
+				}
 
-		var endpointScaleRefs []*ControllerScaleReference
-		for _, scaleRef := range scaleRefs {
-			endpointScaleRefs = append(endpointScaleRefs, scaleRef)
-		}
-		scaleRefsBytes, err := json.Marshal(endpointScaleRefs)
-		if err != nil {
-			return errors.New(fmt.Sprintf("Error annotating Endpoint in namespace %s: %s\n", namespace, err))
-		}
+				var endpointScaleRefs []*ControllerScaleReference
+				for _, scaleRef := range scaleRefs {
+					endpointScaleRefs = append(endpointScaleRefs, scaleRef)
+				}
+				scaleRefsBytes, err := json.Marshal(endpointScaleRefs)
+				if err != nil {
+					return err
+				}
 
-		// Add the scalable resources annotation to the service (endpoint)
-		newEndpoint.Annotations[unidlingapi.UnidleTargetAnnotation] = string(scaleRefsBytes)
-		// Need to delete any previous IdledAtAnnotations to prevent premature unidling
-		if newEndpoint.Annotations[unidlingapi.IdledAtAnnotation] != "" {
-			delete(newEndpoint.Annotations, unidlingapi.IdledAtAnnotation)
+				// Add the scalable resources annotation to the service (endpoint)
+				newEndpoint.Annotations[unidlingapi.UnidleTargetAnnotation] = string(scaleRefsBytes)
+				_, err = endpointInterface.Update(newEndpoint)
+				if err != nil {
+					return err
+				}
+				return nil
+			}
 		}
 	}
-
 	var scaleRefs []ControllerScaleReference
-	if annotation == IdledAtAnnotation || annotation == FullIdleAnnotations {
+	if annotation == IdledAtAnnotation {
+		endpointInterface := c.KubeClient.Endpoints(namespace)
+		newEndpoint, err := c.GetAndCopyEndpoint(namespace, svc.Name)
+		if err != nil {
+			return err
+		}
 		// Add the annotation to the endpoint (service) and use the endpoints ScaleRef annotation to find
 		// which controllers need to be annotated
 		newEndpoint.Annotations[unidlingapi.IdledAtAnnotation] = nowTime.Format(time.RFC3339)
 		scaleRefsBytes := newEndpoint.Annotations[unidlingapi.UnidleTargetAnnotation]
 		err = json.Unmarshal([]byte(scaleRefsBytes), &scaleRefs)
 		if err != nil {
-			return errors.New(fmt.Sprintf("Error annotating DC in namespace %s when unmarshalling scaleRefsBytes from endpoint: %s\n", namespace, err))
+			return err
 		}
-	}
+		_, err = endpointInterface.Update(newEndpoint)
+		if err != nil {
+			return err
+		}
 
-	if annotation == IdledAtAnnotation {
 		// Annotate the controllers
-		// We only need to do this if we're specifically requesting the IdledAtAnnotation,
-		// since FullIdleAnnotations would have already added IdledAt during the previous call to AnnotateController()
 		for _, scaleRef := range scaleRefs {
 			ref := kapi.ObjectReference{
 				Name:      scaleRef.Name,
 				Kind:      scaleRef.Kind,
 				Namespace: svc.Namespace,
 			}
-			_, err := AnnotateController(c, ref, nowTime, annotation)
+			_, err := AnnotateController(c, ref, nowTime, annotation, project.IsAsleep)
 			if err != nil {
-				return errors.New(fmt.Sprintf("Error annotating controller: %s\n", err))
+				return err
 			}
 		}
-	}
-
-	_, err = endpointInterface.Update(newEndpoint)
-	if err != nil {
-		return errors.New(fmt.Sprintf("Error marshalling endpoint scale reference while annotating Endpoint in namespace %s: %s\n", namespace, err))
 	}
 	return nil
 }
 
 // Add idling annotations to a controller based on the `annotation` parameter
-func AnnotateController(c *cache.Cache, ref kapi.ObjectReference, nowTime time.Time, annotation string) (*ControllerScaleReference, error) {
+func AnnotateController(c *cache.Cache, ref kapi.ObjectReference, nowTime time.Time, annotation string, isAsleep bool) (*ControllerScaleReference, error) {
 	obj, err := cache.GetController(ref, c.Factory)
 	if err != nil {
 		return nil, err
@@ -343,24 +313,25 @@ func AnnotateController(c *cache.Cache, ref kapi.ObjectReference, nowTime time.T
 			newDC.Annotations = make(map[string]string)
 		}
 		switch annotation {
-		case FullIdleAnnotations:
-			newDC.Annotations[unidlingapi.PreviousScaleAnnotation] = fmt.Sprintf("%v", controller.Spec.Replicas)
-			newDC.Annotations[unidlingapi.IdledAtAnnotation] = nowTime.Format(time.RFC3339)
 		case IdledAtAnnotation:
 			newDC.Annotations[unidlingapi.IdledAtAnnotation] = nowTime.Format(time.RFC3339)
 		case PreviousScaleAnnotation:
-			newDC.Annotations[unidlingapi.PreviousScaleAnnotation] = fmt.Sprintf("%v", controller.Spec.Replicas)
-			// Need to remove reference to a previous idling, if it exists
 			if newDC.Annotations[unidlingapi.IdledAtAnnotation] != "" {
+				if isAsleep {
+					glog.V(2).Infof("Force-sleeper: Removing stale idled-at annotation in DC( %s ) project( %s )", newDC.Name, controller.Namespace)
+				} else {
+					glog.V(2).Infof("Auto-idler: Removing stale idled-at annotation in DC( %s ) project( %s )", newDC.Name, controller.Namespace)
+				}
 				delete(newDC.Annotations, unidlingapi.IdledAtAnnotation)
 			}
+			newDC.Annotations[unidlingapi.PreviousScaleAnnotation] = fmt.Sprintf("%v", controller.Spec.Replicas)
 		}
 		_, err = dcInterface.Update(newDC)
 		if err != nil {
 			if kerrors.IsNotFound(err) {
 				return nil, nil
 			} else {
-				return nil, errors.New(fmt.Sprintf("Error annotating DC in namespace %s: %s\n", controller.Namespace, err))
+				return nil, err
 			}
 		}
 
@@ -376,17 +347,18 @@ func AnnotateController(c *cache.Cache, ref kapi.ObjectReference, nowTime time.T
 			newRC.Annotations = make(map[string]string)
 		}
 		switch annotation {
-		case FullIdleAnnotations:
-			newRC.Annotations[unidlingapi.PreviousScaleAnnotation] = fmt.Sprintf("%v", controller.Spec.Replicas)
-			newRC.Annotations[unidlingapi.IdledAtAnnotation] = nowTime.Format(time.RFC3339)
 		case IdledAtAnnotation:
 			newRC.Annotations[unidlingapi.IdledAtAnnotation] = nowTime.Format(time.RFC3339)
 		case PreviousScaleAnnotation:
-			newRC.Annotations[unidlingapi.PreviousScaleAnnotation] = fmt.Sprintf("%v", controller.Spec.Replicas)
-			// Need to remove reference to a previous idling, if it exists
 			if newRC.Annotations[unidlingapi.IdledAtAnnotation] != "" {
+				if isAsleep {
+					glog.V(2).Infof("Force-sleeper: Removing stale idled-at annotation in RC( %s ) project( %s )", newRC.Name, controller.Namespace)
+				} else {
+					glog.V(2).Infof("Auto-idler: Removing stale idled-at annotation in RC( %s ) project( %s )", newRC.Name, controller.Namespace)
+				}
 				delete(newRC.Annotations, unidlingapi.IdledAtAnnotation)
 			}
+			newRC.Annotations[unidlingapi.PreviousScaleAnnotation] = fmt.Sprintf("%v", controller.Spec.Replicas)
 		}
 
 		_, err = rcInterface.Update(newRC)
@@ -394,7 +366,7 @@ func AnnotateController(c *cache.Cache, ref kapi.ObjectReference, nowTime time.T
 			if kerrors.IsNotFound(err) {
 				return nil, nil
 			} else {
-				return nil, errors.New(fmt.Sprintf("Error annotating RC in namespace %s: %s\n", controller.Namespace, err))
+				return nil, err
 			}
 		}
 	}


### PR DESCRIPTION
@damemi please review!
fix for https://bugzilla.redhat.com/show_bug.cgi?id=1487500
This PR:
*    sets project.IsAsleep earlier, to avoid idler/force-sleeper conflicts
*    cleans up error msgs/clarifies logging msgs
*    fixes cache, deleted services were not being cleared from cache
