### PR TITLE
fix auto-idling logging msg

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ Every `IDLE_SYNC_PERIOD`, prometheus metrics will be queried to get the cumulati
 
 The auto-idler queries prometheus.  Therefore, prometheus must be deployed in the cluster to run the auto-idling controller.
 
+```
+Note: Prometheus has a default collection interval of 1 minute.  A query has to be at least 2 times
+      that interval.  Therefore, in testing this component, the IDLE_QUERY_PERIOD should never be
+      set to less than 2 minutes.  Prometheus will not return any projects as below idling threshold
+      if the query period is less than 2 minutes.
+```
+
 Usage - deploy in cluster with the following:
 ```
 oc create -f template.yaml -n openshift-infra

--- a/pkg/idling/autoidle.go
+++ b/pkg/idling/autoidle.go
@@ -127,8 +127,6 @@ func (idler *Idler) sync(netmap map[string]float64) {
 				}
 			}
 			if !nsInMap {
-				// Only way to get here is if proj has scalable pods but not in returned map of below_threshold projs
-				glog.V(2).Infof("Auto-idler: Project( %s )network activity above idling threshold", ns)
 				glog.V(2).Infof("Auto-idler: Project( %s )sync complete", ns)
 			}
 		}


### PR DESCRIPTION
@damemi @tiwillia 
This will clear https://bugzilla.redhat.com/show_bug.cgi?id=1517085

Prometheus has a default collection interval of 1 min. A query has to be at least 2 times that interval.  If the idle query period is set too low, under 2m (what was being set for testing only), then the query we use will never return any projects as being below idling threshold.  The logging msg I had set was not 100% accurate, then.  Although we would have never hit this bug in production, still the msg should be removed.  