### PR TITLE
Change pods to store memory limit instead of memory requested

### DIFF
--- a/pkg/cache/resource-store.go
+++ b/pkg/cache/resource-store.go
@@ -604,7 +604,7 @@ func (s *resourceStore) NewResourceFromPod(pod *corev1.Pod) *ResourceObject {
 		Namespace:       pod.ObjectMeta.Namespace,
 		Kind:            PodKind,
 		Terminating:     terminating,
-		MemoryRequested: pod.Spec.Containers[0].Resources.Requests["memory"],
+		MemoryRequested: pod.Spec.Containers[0].Resources.Limits["memory"],
 		RunningTimes:    make([]*RunningTime, 0),
 		Labels:          make(map[string]string),
 		Annotations:     make(map[string]string),


### PR DESCRIPTION
Changes force-sleep to use pod limits instead of pod requests. Tested in a devenv and fixes BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1517134#c6