### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Once a project has exceeded the `QUOTA_HOURS` limit, that project's scalable res
 
 Every `SLEEP_SYNC_PERIOD`, the cached data on each project will be queried and the projects' quota-hour usage will be calculated and, if necessary, force-sleep will be added to (or removed from) the project.
 
-Every `IDLE_SYNC_PERIOD`, prometheus metrics will be queried to get the cumulative network traffic received for all pods in a project over the `IDLE_QUERY_PERIOD`.  If network traffic recieved is below a configured threshold, services in the project will be idled. Also, replication controllers, replicasets, deployments and deployment configs are scaled to 0 and all pods are deleted. Upon receiving network traffic, scalable resources within idled projects are scaled to whatever the value was in the RC/RS/Deployment/DC before being idled. The auto-idler uses the same logic as oc idle and the origin unidling controller.
+Every `IDLE_SYNC_PERIOD`, prometheus metrics will be queried to get the cumulative network traffic received for all pods in a project over the `IDLE_QUERY_PERIOD`.  If network traffic received is below a configured threshold, services in the project will be idled. Also, replication controllers, replicasets, deployments and deployment configs are scaled to 0 and all pods are deleted. Upon receiving network traffic, scalable resources within idled projects are scaled to whatever the value was in the RC/RS/Deployment/DC before being idled. The auto-idler uses the same logic as oc idle and the origin unidling controller.
 
 The auto-idler queries prometheus.  Therefore, prometheus must be deployed in the cluster to run the auto-idling controller.
 


### PR DESCRIPTION
This patch fixes a misspelling error 'recieved' in the README.

Signed-off-by: Marcela Bonell <marcelabonell@gmail.com>