### PR TITLE
Add statefulsets to objects handled

### DIFF
--- a/pkg/cache/resource-store.go
+++ b/pkg/cache/resource-store.go
@@ -11,6 +11,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/apps/v1beta2"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -66,6 +67,8 @@ func (s *resourceStore) NewResourceFromInterface(resource interface{}) (*Resourc
 			return nil, err
 		}
 		return newResource, nil
+	case *v1beta2.StatefulSet:
+		s.excludeStatefulSetNS(r)
 	}
 	return nil, fmt.Errorf("unknown resource of type %T", resource)
 }
@@ -676,6 +679,10 @@ func (s *resourceStore) NewResourceFromRS(rs *v1beta1.ReplicaSet) (*ResourceObje
 		resource.DeletionTimestamp = rs.ObjectMeta.DeletionTimestamp.Time
 	}
 	return resource, nil
+}
+
+func (s *resourceStore) excludeStatefulSetNS(ss *v1beta2.StatefulSet) {
+	s.Exclude[ss.GetNamespace()] = true
 }
 
 func (s *resourceStore) NewResourceFromService(svc *corev1.Service) *ResourceObject {

--- a/pkg/cache/resource-store_test.go
+++ b/pkg/cache/resource-store_test.go
@@ -601,13 +601,13 @@ func TestReplaceWithMultipleDoesNotConflict(t *testing.T) {
 
 	sss, err := store.ByIndex("byNamespaceAndKind", "somens5/"+SSKind)
 	if err != nil {
-		t.Fatalf("unexpected error: %v")
+		t.Fatalf("unexpected error: %v", err)
 	}
 
 	if assert.Len(t, sss, 1, "expected to have one ss in namespace somens5") {
 		selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{MatchLabels: map[string]string{"somessselector": "ssblah"}})
 		if err != nil {
-			t.Fatalf("unexpected error: %v")
+			t.Fatalf("unexpected error: %v", err)
 		}
 		resource := &ResourceObject{
 			UID:               "4445",

--- a/pkg/forcesleep/forcesleep.go
+++ b/pkg/forcesleep/forcesleep.go
@@ -173,6 +173,13 @@ func (s *Sleeper) applyProjectSleep(namespace string, sleepTime, wakeTime time.T
 		glog.Errorf("Force-sleeper: Error scaling ReplicaSets in project( %s ): %s", namespace, err)
 	}
 
+	glog.V(2).Infof("Force-sleeper: Scaling StatefulSets in project( %s )", namespace)
+	err = idling.ScaleProjectSSs(s.resources, namespace)
+	if err != nil {
+		failed = true
+		glog.Errorf("Force-sleeper: Error scaling StatefulSets in project( %s ): %s", namespace, err)
+	}
+
 	glog.V(2).Infof("Force-sleeper: Scaling Deploymentss in project( %s )", namespace)
 	err = idling.ScaleProjectDeployments(s.resources, namespace)
 	if err != nil {

--- a/pkg/idling/autoidle.go
+++ b/pkg/idling/autoidle.go
@@ -303,6 +303,12 @@ func (idler *Idler) autoIdleProjectServices(namespace string) error {
 		return fmt.Errorf("Error scaling ReplicaSets in project %s: %s", namespace, err)
 	}
 
+	glog.V(2).Infof("Auto-idler: Scaling StatefulSets in project %s", namespace)
+	err = ScaleProjectSSs(idler.resources, namespace)
+	if err != nil {
+		return fmt.Errorf("Error scaling StatefulSets in project %s: %s", namespace, err)
+	}
+
 	glog.V(2).Infof("Auto-idler: Deleting pods in project %s", namespace)
 	err = DeleteProjectPods(idler.resources, namespace)
 	if err != nil {


### PR DESCRIPTION
@damemi all the bits to include statefulsets are here, and annotations are all being added correctly.  However, the unidling controller might not handle statefulsets, bc although the unidle-target annotation exists in an endpoint controlled by statefulset, service isn't unidled upon receiving network activity.   We'll have to dig in to origin unidling controller to see what the issue is. 