### PR TITLE
Don't edit annotations if endpoints have no pods, in the case that a project could have auto-idled services with newly created unidled services 

### DIFF
--- a/pkg/idling/idle.go
+++ b/pkg/idling/idle.go
@@ -276,7 +276,13 @@ func AnnotateService(c *cache.Cache, svc *cache.ResourceObject, nowTime time.Tim
 		if err != nil {
 			return err
 		}
-		// Need to delete any previous IdledAtAnnotations to prevent premature unidling
+		// Only add annotations if there are pods associated with the endpoint.
+		// If endpoint subset is nil, that means there is no pod for the endpoint
+		// and the endpoint may already be idled.
+		if newEndpoint.Subsets == nil {
+			return nil
+		}
+		// Need to delete any previous IdledAtAnnotations on services associated with running pods to prevent premature unidling
 		if newEndpoint.Annotations[IdledAtAnnotation] != "" {
 			if project.IsAsleep {
 				glog.V(2).Infof("Force-sleeper: Removing stale idled-at annotation in endpoint( %s ) project( %s )", svc.Name, namespace)


### PR DESCRIPTION
This PR addresses https://bugzilla.redhat.com/show_bug.cgi?id=1532595
I've added a check before idling an endpoint to see if Endpoint.Subsets == nil, that is, an endpoint has no pods associated with it.  If this is the case, we should ignore that service/endpoints/annotations.

This bz deals with a project with idled services.  While idled, a 2nd service/route is created.  Then, when that 2nd service is auto-idled, the current code would edit annotations from all services in the project.  What we need is to only edit the 2nd service annotations, leaving the 1st-already-idled service as/is.

While this scenerio is unlikely in starter clusters, considering the per-project limits set, it is possible, and should be fixed.  The much better fix for this is to use CRD instead of annotations to control idling.  That will be a follow-up PR.