### PR TITLE
Cleanup template file with osoh_uninstall

### DIFF
--- a/ansible/roles/oso_hibernation/tasks/uninstall.yml
+++ b/ansible/roles/oso_hibernation/tasks/uninstall.yml
@@ -16,3 +16,7 @@
     - { kind: "service", name: "{{ osoh_appname }}" }
     - { kind: "clusterrole", name: "{{ osoh_appname }}" }
     - { kind: "template", name: "{{ osoh_appname }}" }
+- name: "Remove {{ osoh_template_path }}"
+  file:
+    path: "{{ osoh_template_path }}"
+    state: absent


### PR DESCRIPTION
When running osoh_uninstall, have to remove the template file.  Otherwise, template|changed does not register on next run.