### PR TITLE
add openshift projects to list of excluded ns

### DIFF
--- a/ansible/roles/oso_hibernation/defaults/main.yml
+++ b/ansible/roles/oso_hibernation/defaults/main.yml
@@ -22,4 +22,4 @@ osoh_sleeper_dryrun: "{{ osoh_sleeper_dryrun | default('True') }}"
 osoh_uninstall: False
 
 # Namespaces to exclude from hibernation
-osoh_exclude_namespace: "openshift,openshift-devops-monitor,openshift-infra,openshift-image-inspector,openshift-metrics,openshift-node,openshift-web-console,prometheus,default,logging,kube-system,kube-public,kube-service-catalog,management-infra,ops-health-monitoring"
+osoh_exclude_namespace: "openshift,openshift-clam-server,openshift-config,openshift-devops-monitor,openshift-infra,openshift-image-inspector,openshift-metrics,openshift-monitoring,openshift-node,openshift-sdn,openshift-web-console,prometheus,default,logging,kube-system,kube-public,kube-service-catalog,management-infra,ops-health-monitoring"


### PR DESCRIPTION
@abhgupta @dak1n1 
The list should be checked, but looking at free-int there are a few openshift projects that should be added.  
'openshift-sdn' will be added as/of ocp 3.10, AFAICT.

TODO: get a better system for excluding ns from online-hibernation