### PR TITLE
edit idle-threshold=1 and idle_query=24h

### DIFF
--- a/ansible/roles/oso_hibernation/templates/hibernation-template.yaml.j2
+++ b/ansible/roles/oso_hibernation/templates/hibernation-template.yaml.j2
@@ -37,10 +37,10 @@ parameters:
   value: "8h"
 - name: IDLE_QUERY_PERIOD
   description: Interval to query project network activity for idler
-  value: "8h"
+  value: "24h"
 - name: IDLE_THRESHOLD
   description: Network activity received (bytes) or less that will result in idling.
-  value: "40000"
+  value: "1"
 - name: IDLE_DRYRUN
   description: Boolean for idler dry-run mode, where projects will be logged but not idled.
   value: "true"


### PR DESCRIPTION
@dak1n1, @abhgupta  running oso_deployer on a cluster with 'osod_hibernation_idler_dryrun=False' set should result in non-dryRun for auto-idling only, and only for that cluster where that var is set. :+1: 